### PR TITLE
Update webapp.flow example to fix syntax errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ diagram {
 
     It's **extremely** safe.`
 
-  boundary {
+  boundary browser {
     title = "Browser"
 
     function client {
@@ -188,7 +188,7 @@ diagram {
     }
   }
 
-  boundary {
+  boundary aws {
     title = "Amazon AWS"
 
     function server {


### PR DESCRIPTION
Hi,


I noticed this when I was trying out the README example.  Without the proposed change, the command to convert this flow document to dfd fails:

```
$ dataflow dfd webapp.flow
"webapp.flow" (line 7, column 12):
unexpected "{"
expecting space, "->", "--" or "<-"
```

Thanks for the great tool!